### PR TITLE
add files and bin to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,17 @@
 	"description": "A clean REST API wrapping around the Deutsche Bahn API.",
 	"version": "6.0.3",
 	"type": "module",
+	"bin": {
+		"db-rest": "./index.js"
+	},
 	"main": "index.js",
+	"files": [
+		"docs",
+		"lib",
+		"routes",
+		"api.js",
+		"index.js"
+	],
 	"author": "Jannis R <mail@jannisr.de>",
 	"homepage": "https://github.com/derhuerst/db-rest/tree/6",
 	"repository": "derhuerst/db-rest",


### PR DESCRIPTION
adds bin and files properties to package.json.
these are the files which are required for the final package.
This is required for packaging in [nixpkgs](https://github.com/nixos/nixpkgs) and while i could patch this in, it's much easier to upstream this.
